### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='QubeSpec',
         'scipy>=1.9.1',
         'multiprocess',
         'spectres',
-        'photoutils',
+        'photutils',
         'sep'],
       python_requires='>=3.8.0',
       #entry_points={


### PR DESCRIPTION
The `setup.py` currently requires the `photoutils` module instead of `photutils`